### PR TITLE
Update sync_mediawiki.yml

### DIFF
--- a/.github/workflows/sync_mediawiki.yml
+++ b/.github/workflows/sync_mediawiki.yml
@@ -10,6 +10,11 @@ on:
       - src/**/*.css
       - src/**/.options
 
+# Disallow parallel running
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sync_codes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
不允许同时运行两个sync_mediawiki工作流实例，避免旧版本覆盖新版本